### PR TITLE
Fix: Correct SyntaxError in ai_service.py

### DIFF
--- a/backend/app/ai_service.py
+++ b/backend/app/ai_service.py
@@ -74,8 +74,7 @@ class ResponseParser:
         # Try keyword-based extraction (simplified)
         # This fallback is basic and might need more sophisticated logic depending on actual legacy formats
         for keyword in keywords.get(section_type, []):
-            # Attempt to find "Keyword:[ ]Content" or "Keyword
-Content"
+            # Attempt to find "Keyword:[ ]Content" or "Keyword\nContent"
             # This regex is an example and may need refinement
             pattern = rf'{re.escape(keyword)}.*?(?:[:：]|\n)\s*(.*?)(?=\n\n|\n(?:###[A-Z_]+_START###|1\.|2\.|3\.|4\.)|$)'
             match = re.search(pattern, content, re.DOTALL | re.IGNORECASE)


### PR DESCRIPTION
Corrects an "unterminated string literal" SyntaxError in backend/app/ai_service.py. The error was caused by a malformed comment spanning multiple lines within the `_fallback_extract` method.

The specific change reformats the comment at lines 77-78 to be syntactically correct, ensuring the Python interpreter can parse the file without issues.