### PR TITLE
Fix: Resolve ImportError for ai_service in sessions.py

### DIFF
--- a/backend/app/ai_service.py
+++ b/backend/app/ai_service.py
@@ -657,4 +657,4 @@ class AIService:
 # Depending on application structure (e.g., FastAPI), dependency injection might be used instead.
 # For now, as per original structure, a direct instance can be created if needed elsewhere.
 # However, it's often better to instantiate it where used or use a factory/DI.
-# ai_service = AIService()
+ai_service = AIService()


### PR DESCRIPTION
Corrects an ImportError where `ai_service` could not be imported from `app.ai_service`. The issue was caused by the singleton instance `ai_service = AIService()` being commented out at the end of `ai_service.py`.

This commit uncomments the instantiation of `AIService`, ensuring that the `ai_service` object is available for import by other modules, such as the sessions router.